### PR TITLE
Browser safe statebox

### DIFF
--- a/lib/dao/Memory-dao.js
+++ b/lib/dao/Memory-dao.js
@@ -1,15 +1,13 @@
-const process = require('process')
-const _ = require('lodash')
+
 const Dao = require('./Dao')
-const Status = require('../Status')
 
 class MemoryDao extends Dao {
-  constructor (options) {
+  constructor () {
     super()
     this.uuid = 0
     this.executions = {}
   }
-  
+
   /// ////////////////////////////////////
   _newExecutionName (stateMachineName) {
     this.uuid++

--- a/lib/dao/Memory-dao.js
+++ b/lib/dao/Memory-dao.js
@@ -9,38 +9,7 @@ class MemoryDao extends Dao {
     this.uuid = 0
     this.executions = {}
   }
-
-  getBranchSummary (parentExecutionName, callback) {
-    const _this = this
-    process.nextTick(
-      function () {
-        const summary = {
-          numberOfBranches: 0,
-          numberSucceeded: 0,
-          numberFailed: 0
-        }
-        _.forOwn(
-          _this.executions,
-          function (execution) {
-            if (execution.hasOwnProperty('parentExecutionName') && execution.parentExecutionName === parentExecutionName) {
-              summary.numberOfBranches++
-              switch (execution.status) {
-                case Status.SUCCEEDED:
-                  summary.numberSucceeded++
-                  break
-
-                case Status.FAILED:
-                  summary.numberFailed++
-                  break
-              }
-            }
-          }
-        )
-        callback(null, summary)
-      }
-    )
-  }
-
+  
   /// ////////////////////////////////////
   _newExecutionName (stateMachineName) {
     this.uuid++

--- a/lib/state-machines/state-types/Task.js
+++ b/lib/state-machines/state-types/Task.js
@@ -1,10 +1,8 @@
-'use strict'
 const BaseStateType = require('./Base-state')
 const resources = require('./../../resources')
 const boom = require('boom')
 const jp = require('jsonpath')
 const convertJsonpathToDottie = require('./../../utils/convert-jsonpath-to-dottie')
-const process = require('process')
 const _ = require('lodash')
 const debug = require('debug')('statebox')
 
@@ -160,45 +158,42 @@ class Task extends BaseStateType {
   } // resourceInit
 
   process (executionDescription, optionalDoneCallback) {
-    const _this = this
     const input = jp.value(executionDescription.ctx, this.inputPath)
     const context = new Context(executionDescription, this)
 
-    process.nextTick(
-      function () {
-        try {
-          _this.resource.run(
-            input,
-            context,
-            optionalDoneCallback
-          )
-        } catch (e) {
-          console.error(
-            '\nUNHANDLED EXCEPTION WHILE PROCESSING TASK ------------------------------------\n' +
-            `error: ${e}\n` +
-            `executionName: ${executionDescription.executionName}\n` +
-            `stateMachineName: ${executionDescription.stateMachineName}\n` +
-            `currentStateName: ${executionDescription.currentStateName}\n` +
-            `parentExecutionName: ${executionDescription.executionOptions.parentExecutionName}\n` +
-            `rootExecutionName: ${executionDescription.executionOptions.rootExecutionName}\n` +
-            `startDate: ${executionDescription.startDate}\n` +
-            `ctx: ${JSON.stringify(executionDescription.ctx)}\n\n` +
-            'STACK\n' +
-            '-----\n' +
-            e.stack + '\n' +
-            '------------------------------------------------------------------------------\n'
-          )
-          // TODO: Sending out error details might leak security info... implement "dev mode" flag?
-          _this.processTaskFailure(
-            {
-              error: 'States.TaskFail',
-              cause: e.toString()
-            },
-            executionDescription.executionName
-          )
-        }
+    Promise.resolve().then(() => {
+      try {
+        this.resource.run(
+          input,
+          context,
+          optionalDoneCallback
+        )
+      } catch (e) {
+        console.error(
+          '\nUNHANDLED EXCEPTION WHILE PROCESSING TASK ------------------------------------\n' +
+          `error: ${e}\n` +
+          `executionName: ${executionDescription.executionName}\n` +
+          `stateMachineName: ${executionDescription.stateMachineName}\n` +
+          `currentStateName: ${executionDescription.currentStateName}\n` +
+          `parentExecutionName: ${executionDescription.executionOptions.parentExecutionName}\n` +
+          `rootExecutionName: ${executionDescription.executionOptions.rootExecutionName}\n` +
+          `startDate: ${executionDescription.startDate}\n` +
+          `ctx: ${JSON.stringify(executionDescription.ctx)}\n\n` +
+          'STACK\n' +
+          '-----\n' +
+          e.stack + '\n' +
+          '------------------------------------------------------------------------------\n'
+        )
+        // TODO: Sending out error details might leak security info... implement "dev mode" flag?
+        this.processTaskFailure(
+          {
+            error: 'States.TaskFail',
+            cause: e.toString()
+          },
+          executionDescription.executionName
+        )
       }
-    )
+    })
   }
 }
 

--- a/lib/state-machines/state-types/Wait.js
+++ b/lib/state-machines/state-types/Wait.js
@@ -1,7 +1,5 @@
-'use strict'
 const BaseStateType = require('./Base-state')
 const debug = require('debug')('statebox')
-const process = require('process')
 const convertJsonpathToDottie = require('./../../utils/convert-jsonpath-to-dottie')
 
 /* https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-wait-state.html */
@@ -46,7 +44,7 @@ class Wait extends BaseStateType {
     const context = new Context(executionDescription, this)
     this.timeout *= 1000
 
-    process.nextTick(
+    Promise.resolve().then(
       () => {
         try {
           setTimeout(() => {

--- a/test/example-form-filling.js
+++ b/test/example-form-filling.js
@@ -84,8 +84,8 @@ describe('Form-filling', () => {
           expect(executionDescription.stateMachineName).to.eql('formFilling')
         })
 
-        it('sendTaskSuccess (i.e. some completed form data)', async () => {
-          const execDesc = await statebox.sendTaskSuccess(
+        it('sendTaskSuccess (i.e. some completed form data)', () => {
+          return statebox.sendTaskSuccess(
             executionName,
             {
               formData: {
@@ -93,8 +93,6 @@ describe('Form-filling', () => {
               }
             } // output
           )
-
-          expect(execDesc.status).to.eql('RUNNING')
         })
 
         it('form-filling completed', async () => {


### PR DESCRIPTION
Switch from process.nextTick to Promise.resolve().then …

Both process.nextTime and Promise.resolve().then defer work to the queue (albeit in very slightly
different ways).  process.nextTick can be polyfilled, but Promise.resolve().then, however, can be used 'natively' both server and browser side. If we get ride of Node specific calls, we should be able to embed statebox (and, ultimately, Tymly) in the browser.