### PR TITLE
Add sendTaskLastHeartbeat 

### DIFF
--- a/lib/dao/Dao.js
+++ b/lib/dao/Dao.js
@@ -1,5 +1,5 @@
 const Status = require('../Status')
-const boom = require('boom')
+const boom = require('@hapi/boom')
 
 class Dao {
   /// /////////////////////////

--- a/lib/executioner.js
+++ b/lib/executioner.js
@@ -1,5 +1,5 @@
 const stateMachines = require('./state-machines')
-const boom = require('boom')
+const boom = require('@hapi/boom')
 
 async function executioner (input, stateMachineName, executionOptions, options) {
   // References

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,7 +192,15 @@ class Statebox {
     }
   } // sendTaskFailure
 
-  async sendTaskHeartbeat (executionName, options) {
+  sendTaskHeartbeat (executionName, updateResult) {
+    return this.sendHeartbeat_(executionName, updateResult, false)
+  } // _sendTaskHeartbeat
+
+  sendTaskLastHeartbeat (executionName, updateResult) {
+    return this.sendHeartbeat_(executionName, updateResult, true)
+  } // sendTaskLastHeartbeat
+
+  async sendHeartbeat_ (executionName, updateResult, isLast) {
     const executionDescription = await this.options.dao.findExecutionByName(executionName)
 
     if (executionDescription && executionDescription.status === Status.RUNNING) {
@@ -200,11 +208,11 @@ class Statebox {
         executionDescription.stateMachineName,
         executionDescription.currentStateName
       )
-      return stateToRun.runTaskHeartbeat(executionDescription, options)
+      return stateToRun.runTaskHeartbeat(executionDescription, updateResult, isLast)
     } else {
       throw new Error(`Heartbeat has been rejected because execution is not running (executionName='${executionName}')`)
     }
-  } // _sendTaskHeartbeat
+  }
 
   async sendTaskRevivification (executionName) {
     const executionDescription = await this.options.dao.findExecutionByName(executionName)

--- a/lib/state-machines/State-machine.js
+++ b/lib/state-machines/State-machine.js
@@ -1,7 +1,7 @@
 'use strict'
 const debug = require('debug')('statebox')
 const stateTypes = require('./state-types')
-const boom = require('boom')
+const boom = require('@hapi/boom')
 
 class StateMachine {
   init (stateMachineName, definition, stateMachineMeta, env, options) {

--- a/lib/state-machines/state-types/Base-state.js
+++ b/lib/state-machines/state-types/Base-state.js
@@ -128,7 +128,7 @@ class BaseState {
     )
   } // processTaskHeartbeat
 
-  async runTaskHeartbeat (executionDescription, updateResult) {
+  async runTaskHeartbeat (executionDescription, updateResult, isLast = false) {
     const executionName = executionDescription.executionName
     const intermediateResult = this.applyResult(executionDescription.ctx, updateResult)
     const output = this.outputSelector(intermediateResult)
@@ -141,6 +141,11 @@ class BaseState {
       executionDescription.currentResource, // nextResource
       executionDescription.ctx
     )
+
+    if (isLast) {
+      // this was the last heartbeat, so advance to the next stage
+      this.runTaskSuccess(executionDescription, executionName.ctx)
+    }
 
     return executionDescription
   } // runTaskHeartbeat

--- a/lib/state-machines/state-types/Task.js
+++ b/lib/state-machines/state-types/Task.js
@@ -1,6 +1,6 @@
 const BaseStateType = require('./Base-state')
 const Resources = require('./../../resources')
-const boom = require('boom')
+const boom = require('@hapi/boom')
 const jp = require('jsonpath')
 const _ = require('lodash')
 const debug = require('debug')('statebox')

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jsonpath": "1.0.2",
     "lodash": "4.17.15",
     "luxon": "1.22.0",
-    "uuid": "7.0.1"
+    "uuid": "7.0.2"
   },
   "devDependencies": {
     "@semantic-release/changelog": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
+    "@hapi/boom": "9.1.0",
     "@wmfs/asl-choice-processor": "1.14.0",
     "async": "3.2.0",
-    "@hapi/boom": "9.1.0",
     "debug": "4.1.1",
     "deepmerge": "4.2.2",
     "dottie": "2.0.2",
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "5.0.1",
     "@semantic-release/git": "9.0.0",
+    "axios": "0.19.2",
     "chai": "4.2.0",
     "chai-string": "1.5.0",
     "chai-subset": "1.6.0",
@@ -46,8 +47,6 @@
     "express": "4.17.1",
     "mocha": "7.1.1",
     "nyc": "15.0.0",
-    "request-promise-native": "1.0.8",
-    "request": "2.88.2",
     "semantic-release": "17.0.4",
     "standard": "14.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dottie": "2.0.2",
     "jsonpath": "1.0.2",
     "lodash": "4.17.15",
-    "luxon": "1.22.0",
+    "luxon": "1.22.2",
     "uuid": "7.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "./lib/index.js",
   "dependencies": {
     "@wmfs/asl-choice-processor": "1.14.0",
-    "async": "3.1.1",
+    "async": "3.2.0",
     "boom": "7.3.0",
     "debug": "4.1.1",
     "deepmerge": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@wmfs/asl-choice-processor": "1.14.0",
     "async": "3.2.0",
-    "boom": "7.3.0",
+    "@hapi/boom": "9.1.0",
     "debug": "4.1.1",
     "deepmerge": "4.2.2",
     "dottie": "2.0.2",

--- a/test/fixtures/module-resources/HttpCantConnect.js
+++ b/test/fixtures/module-resources/HttpCantConnect.js
@@ -1,17 +1,8 @@
-'use strict'
-
-const requestPromise = require('request-promise-native')
+const axios = require('axios')
 
 module.exports = class Failure {
-  init (resourceConfig, env, callback) {
-    callback(null)
-  }
-
   run (event, context) {
-    const rp = requestPromise.defaults()
-    rp({
-      uri: 'http://localhost:9999/please-just-fail'
-    })
+    axios.get('http://localhost:9999/please-just-fail')
       .catch(err => context.sendTaskFailure(err))
   } // run
 }

--- a/test/fixtures/module-resources/HttpNotFound.js
+++ b/test/fixtures/module-resources/HttpNotFound.js
@@ -1,17 +1,8 @@
-'use strict'
-
-const requestPromise = require('request-promise-native')
+const axios = require('axios')
 
 module.exports = class Failure {
-  init (resourceConfig, env, callback) {
-    callback(null)
-  }
-
   run (event, context) {
-    const rp = requestPromise.defaults()
-    rp({
-      uri: 'http://localhost:3003/not-found'
-    })
+    axios.get('http://localhost:3003/not-found')
       .catch(err => context.sendTaskFailure(err))
   } // run
 }

--- a/test/task-failure-handling.js
+++ b/test/task-failure-handling.js
@@ -91,28 +91,14 @@ describe('Task failure handling', () => {
       it('StatusCodeError - HTTP not found', async () => {
         const executionDescription = await run('errorHttpNotFound')
 
-        expect(executionDescription.errorCode).to.eql('StatusCodeError')
-        expect(executionDescription.errorMessage).to.startWith('404 -')
-        expect(executionDescription.executionOptions.error).contains({
-          error: 'StatusCodeError',
-          statusCode: 404
-        })
-        expect(executionDescription.executionOptions.error.options).exist()
-        expect(executionDescription.executionOptions.error.response).exist()
-        expect(executionDescription.executionOptions.error.stack).not.exist()
+        expect(executionDescription.errorCode).to.eql('Error')
+        expect(executionDescription.errorMessage).to.contain('404')
       })
       it('StatusCodeError - HTTP can\'t connect', async () => {
         const executionDescription = await run('errorHttpCantConnect')
 
-        expect(executionDescription.errorCode).to.eql('RequestError')
-        expect(executionDescription.errorMessage).to.eql('Error: connect ECONNREFUSED 127.0.0.1:9999')
-        expect(executionDescription.executionOptions.error).contains({
-          error: 'RequestError',
-          cause: 'Error: connect ECONNREFUSED 127.0.0.1:9999'
-        })
-        expect(executionDescription.executionOptions.error.options).not.exist()
-        expect(executionDescription.executionOptions.error.response).not.exist()
-        expect(executionDescription.executionOptions.error.stack).exist()
+        expect(executionDescription.errorCode).to.eql('Error')
+        expect(executionDescription.errorMessage).to.eql('connect ECONNREFUSED 127.0.0.1:9999')
       })
     })
   })


### PR DESCRIPTION
sendTaskHeartbeat updates an execution's context. 
One state machine can call sendTaskHeartbeat on another to send period updates. However, if it calls sendTaskSuccess to indicate that no further updates are forthcoming and that receiver can advance to the next state, any output sent will _overwrite_ rather than update the receiving execution's context. This could be really quite bad.

The new sendTaskLastHeartbeat allows a state machine to send an update and also indicate no further updates are coming. The receiving state machine is updated, and then advanced to the next state.

This is a niche use case, but when you need it, you really need it.