### PR TITLE
Don't pass callback parameter to state resource inits

### DIFF
--- a/lib/Callback-manager.js
+++ b/lib/Callback-manager.js
@@ -1,4 +1,6 @@
 
+const Status = require('./Status')
+
 class Latch {
   constructor () {
     this.promise_ = new Promise(resolve => {
@@ -47,7 +49,7 @@ class CallbackManager {
   hasEvent (eventName, executionName) {
     return Object.prototype.hasOwnProperty.call(this.callbacks, executionName) &&
       (this.callbacks[executionName].eventName === eventName ||
-       eventName === 'COMPLETE') // if complete, fire any callback
+       eventName === Status.COMPLETE) // if complete, fire any callback
   } // hasEvent
 } // CallbackManager
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -156,10 +156,6 @@ class Statebox {
     }
   } // _stopExecution
 
-  listExecutions (executionOptions, callback) {
-    callback(null)
-  }
-
   describeExecution (executionName) {
     return this.options.dao.findExecutionByName(executionName)
   } // describeExecution

--- a/lib/resources/modules/ModuleResource.js
+++ b/lib/resources/modules/ModuleResource.js
@@ -24,24 +24,10 @@ class ModuleResource {
       env
     ]
 
-    if (ModuleResource.wantsCallback(resource.init)) {
-      await new Promise((resolve, reject) =>
-        resource.init(
-          ...args,
-          err => err ? reject(err) : resolve()
-        )
-      )
-    } else {
-      await resource.init(...args)
-    }
+    await resource.init(...args)
 
     this.resourceConfigure(resource)
   } // resourceInit
-
-  static wantsCallback (initFn) {
-    const hasCallback = (initFn.length === 3)
-    return hasCallback
-  } // wantsCallback
 
   resourceConfigure (resource) {
     const requiredConfig = _.get(resource, 'schema.required')

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@hapi/boom": "9.1.0",
     "@wmfs/asl-choice-processor": "1.14.0",
-    "async": "3.2.0",
     "debug": "4.1.1",
     "deepmerge": "4.2.2",
     "dottie": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@hapi/boom": "9.1.0",
     "@wmfs/asl-choice-processor": "1.14.0",
     "debug": "4.1.1",
-    "deepmerge": "4.2.2",
     "dottie": "2.0.2",
     "jsonpath": "1.0.2",
     "lodash": "4.17.15",

--- a/test/fixtures/module-resources/Exception.js
+++ b/test/fixtures/module-resources/Exception.js
@@ -1,10 +1,6 @@
 'use strict'
 
-module.exports = class Failure {
-  init (resourceConfig, env, callback) {
-    callback(null)
-  }
-
+module.exports = class Exception {
   run (event, context) {
     const obj = { }
     try {

--- a/test/fixtures/module-resources/FailWithError.js
+++ b/test/fixtures/module-resources/FailWithError.js
@@ -1,9 +1,6 @@
 'use strict'
 
 module.exports = class Failure {
-  init (resourceConfig, env) {
-  }
-
   run (event, context) {
     // generate an exception
     const hello = null

--- a/test/fixtures/module-resources/Failure.js
+++ b/test/fixtures/module-resources/Failure.js
@@ -1,9 +1,6 @@
 'use strict'
 
 module.exports = class Failure {
-  init (resourceConfig, env) {
-  }
-
   run (event, context) {
     context.sendTaskFailure(
       {

--- a/test/fixtures/module-resources/HttpCantConnect.js
+++ b/test/fixtures/module-resources/HttpCantConnect.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 
-module.exports = class Failure {
+module.exports = class HttpCantConnect {
   run (event, context) {
     axios.get('http://localhost:9999/please-just-fail')
       .catch(err => context.sendTaskFailure(err))

--- a/test/fixtures/module-resources/HttpNotFound.js
+++ b/test/fixtures/module-resources/HttpNotFound.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 
-module.exports = class Failure {
+module.exports = class HttpNotFound {
   run (event, context) {
     axios.get('http://localhost:3003/not-found')
       .catch(err => context.sendTaskFailure(err))

--- a/test/fixtures/module-resources/Ilive.js
+++ b/test/fixtures/module-resources/Ilive.js
@@ -1,4 +1,4 @@
-module.exports = class Hello {
+module.exports = class ILive {
   run (event, context) {
     context.sendTaskSuccess()
   }

--- a/test/fixtures/module-resources/Subtract.js
+++ b/test/fixtures/module-resources/Subtract.js
@@ -1,10 +1,6 @@
 'use strict'
 
 module.exports = class Subtract {
-  init (resourceConfig, env, callback) {
-    callback(null)
-  }
-
   run (event, context) {
     context.sendTaskSuccess(event.number1 - event.number2)
   }


### PR DESCRIPTION
If a state resource init methods can be async, so there is no longer any need to pass the callback parameter into them. 

I've audited the whole code pass, updating init methods as appropriate. Turns out, some were already new no-callback style, the rest had callback(null) as their last line. We've lost nothing here but tedious house keeping.