### PR TITLE
State resource run refactor

### DIFF
--- a/lib/state-machines/State-machine.js
+++ b/lib/state-machines/State-machine.js
@@ -51,30 +51,37 @@ class StateMachine {
 
     debug(`About to process ${stateToRun.stateType} '${stateNameToRun}' in stateMachine '${this.name}' stateMachine (executionName='${executionDescription.executionName}')`)
 
+    this.enteringState(executionDescription)
+
+    const latch = stateToRun.run(executionDescription)
+
+    if (!Array.isArray(latch)) return latch
+
+    const [onComplete, onHeartbeat] = latch
+    onHeartbeat.then(updatedExecutionDescription => this.leftState(updatedExecutionDescription))
+    return onComplete
+  } // runState
+
+  enteringState (executionDescription) {
     this.callbackManager.fireCallback(
-      'ENTERING:' + stateNameToRun,
+      `ENTERING:${executionDescription.currentStateName}`,
       executionDescription.executionName,
       executionDescription
     )
+  } // enteringState
 
-    const continuation = stateToRun.resourceExpectsDoneCallback
-      ? (postProcessExecutionDescription) => {
-        // AFTER_RESOURCE_CALLBACK.TYPE:Form-filling
-        const resourceName = postProcessExecutionDescription.currentResource.split(':')[1]
-        const eventName = 'AFTER_RESOURCE_CALLBACK.TYPE:' + resourceName
-        this.callbackManager.fireCallback(
-          eventName,
-          postProcessExecutionDescription.executionName,
-          postProcessExecutionDescription
-        )
-      }
-      : null
+  async leftState (executionDescription) {
+    if (!executionDescription.currentResource) return
 
-    return stateToRun.run(
-      executionDescription,
-      continuation
+    const resourceName = executionDescription.currentResource.split(':')[1]
+    const eventName = `AFTER_RESOURCE_CALLBACK.TYPE:${resourceName}`
+
+    this.callbackManager.fireCallback(
+      eventName,
+      executionDescription.executionName,
+      executionDescription
     )
-  } // runState
+  } // leftState
 
   async processState (executionName) {
     const executionDescription = await this.options.dao.findExecutionByName(executionName)

--- a/lib/state-machines/state-types/Task.js
+++ b/lib/state-machines/state-types/Task.js
@@ -15,26 +15,29 @@ class Context {
     this.stateMachineMeta = task.stateMachine.meta
     this.task = task
 
-    this.toggle = null
-    this.latch = new Promise(resolve => { this.toggle = resolve })
+    this.complete = null
+    this.heartbeat = null
+    this.onComplete = new Promise(resolve => { this.complete = resolve })
+    this.onHeartbeat = new Promise(resolve => { this.heartbeat = resolve })
   }
 
   sendTaskSuccess (output) {
     debug(`sendTaskSuccess(${this.executionName})`)
     this.task.processTaskSuccess(this.executionName, output)
-      .then(result => this.toggle(result))
+      .then(result => this.complete(result))
   }
 
   sendTaskFailure (errorInfo) {
     console.error(`sendTaskFailure(${this.executionName}, ${JSON.stringify(errorInfo)})`)
     debug(`sendTaskFailure(${this.executionName}, ${JSON.stringify(errorInfo)})`)
     this.task.processTaskFailure(errorInfo, this.executionName)
-      .then(result => this.toggle(result))
+      .then(result => this.complete(result))
   }
 
   sendTaskHeartbeat (output) {
     debug(`sendTaskHeartbeat(${this.executionName})`)
     return this.task.processTaskHeartbeat(output, this.executionName)
+      .then(result => this.heartbeat(result))
   }
 
   resolveInputPaths (input, template) {
@@ -127,7 +130,7 @@ class Task extends BaseStateType {
       }
     })
 
-    return context.latch
+    return [context.onComplete, context.onHeartbeat]
   }
 }
 

--- a/lib/state-machines/state-types/Task.js
+++ b/lib/state-machines/state-types/Task.js
@@ -37,7 +37,7 @@ class Context {
   sendTaskHeartbeat (output) {
     debug(`sendTaskHeartbeat(${this.executionName})`)
     return this.task.processTaskHeartbeat(output, this.executionName)
-      .then(result => this.heartbeat(result))
+      .then(result => { this.heartbeat(result); return result })
   }
 
   resolveInputPaths (input, template) {

--- a/test/example-form-filling.js
+++ b/test/example-form-filling.js
@@ -17,11 +17,10 @@ describe('Form-filling', () => {
   DaosToTest.forEach(([name, options]) => {
     describe(`Using ${name}`, function () {
       this.timeout(process.env.TIMEOUT || 5000)
-      let statebox
+      const statebox = new Statebox(options)
       let executionName
 
       before('setup statebox', async () => {
-        statebox = new Statebox(options)
         await statebox.ready
         statebox.createModuleResources(moduleResources)
         await Promise.all(
@@ -58,8 +57,7 @@ describe('Form-filling', () => {
             executionName,
             {
               some: 'payload'
-            }, // output
-            {}
+            }
           )
 
           expect(execDesc.status).to.eql('RUNNING')
@@ -220,8 +218,7 @@ describe('Form-filling', () => {
               formData: {
                 name: 'Rupert'
               }
-            }, // output
-            {} // executionOptions
+            } // executionOptions
           )
             .then(() => done(new Error('expected an error')))
             .catch(() => done())

--- a/test/fixtures/module-resources/Form-filling.js
+++ b/test/fixtures/module-resources/Form-filling.js
@@ -1,12 +1,10 @@
 module.exports = class FormFilling {
-  async run (event, context, done) {
+  run (event, context) {
     console.log('WAITING FOR SOMEONE TO FILL-IN A FORM!')
-    const executionDescription = await context.sendTaskHeartbeat(
+    context.sendTaskHeartbeat(
       {
         formId: 'fillThisFormInHuman!'
       }
     )
-
-    done(executionDescription)
   }
 }


### PR DESCRIPTION
Rework state-resource run calls so that the AFTER_CALLBACK_TYPE event is raised after a call to sendTaskHeartbeat. There's no longer any need to pass a callback function into the state resource, and so nothing special needed in the state resource implementation.