### PR TITLE
Context object support

### DIFF
--- a/lib/state-machines/state-types/Base-state.js
+++ b/lib/state-machines/state-types/Base-state.js
@@ -3,6 +3,7 @@ const debugPackage = require('debug')('statebox')
 const _ = require('lodash')
 const Status = require('../../Status')
 const States = require('./errors')
+const ExecutionContext = require('./execution-context')
 
 const PathHandlers = require('./path-handlers')
 
@@ -35,7 +36,7 @@ class BaseState {
 
   run (executionDescription) {
     try {
-      const input = this.inputSelector(executionDescription.ctx, {})
+      const input = this.inputSelector(executionDescription.ctx, ExecutionContext(executionDescription))
       return this.process(executionDescription, input)
     } catch (e) {
       return this.processTaskFailure(e, executionDescription.executionName)

--- a/lib/state-machines/state-types/Base-state.js
+++ b/lib/state-machines/state-types/Base-state.js
@@ -35,7 +35,7 @@ class BaseState {
 
   run (executionDescription) {
     try {
-      const input = this.inputSelector(executionDescription.ctx)
+      const input = this.inputSelector(executionDescription.ctx, {})
       return this.process(executionDescription, input)
     } catch (e) {
       return this.processTaskFailure(e, executionDescription.executionName)

--- a/lib/state-machines/state-types/Task.js
+++ b/lib/state-machines/state-types/Task.js
@@ -1,7 +1,5 @@
 const BaseStateType = require('./Base-state')
 const boom = require('@hapi/boom')
-const jp = require('jsonpath')
-const _ = require('lodash')
 const debug = require('debug')('statebox')
 const States = require('./errors')
 
@@ -38,40 +36,7 @@ class Context {
     return this.task.processTaskHeartbeat(output, this.executionName)
       .then(result => { this.heartbeat(result); return result })
   }
-
-  resolveInputPaths (input, template) {
-    const clonedInput = cloneOrDefault(input)
-    const clonedTemplate = cloneOrDefault(template)
-    resolvePaths(clonedInput, clonedTemplate)
-    return clonedTemplate
-  }
 }
-
-function cloneOrDefault (obj) {
-  return (_.isObject(obj)) ? _.cloneDeep(obj) : { }
-} // cloneOrDefault
-
-function resolvePaths (input, root) {
-  if (!_.isObject(root)) return
-
-  // TODO: Support string-paths inside arrays
-  if (Array.isArray(root)) {
-    root.forEach(element => resolvePaths(input, element))
-    return
-  }
-
-  for (const [key, value] of Object.entries(root)) {
-    if (isJSONPath(value)) {
-      root[key] = jp.value(input, value)
-    } else {
-      resolvePaths(input, value)
-    }
-  } // for ...
-} // resolvePaths
-
-function isJSONPath (p) {
-  return _.isString(p) && p.length !== 0 && p[0] === '$'
-} // isJSONPath
 
 /// //////////////////////////////////
 class Task extends BaseStateType {

--- a/lib/state-machines/state-types/execution-context/index.js
+++ b/lib/state-machines/state-types/execution-context/index.js
@@ -1,0 +1,11 @@
+const { DateTime } = require('luxon')
+
+class ExecutionContext {
+  constructor (execDesc) {
+    this.execDesc = execDesc
+  }
+
+  get DayOfWeek () { return DateTime.local().weekdayLong }
+}
+
+module.exports = executionDescription => new ExecutionContext(executionDescription)

--- a/lib/state-machines/state-types/path-handlers/input-path-handler.js
+++ b/lib/state-machines/state-types/path-handlers/input-path-handler.js
@@ -8,7 +8,7 @@ function inputPathHandler (inputPath, parameters) {
   const path = findSelector(inputPath)
   const parameterTemplate = payloadTemplateHandler(parameters)
 
-  return ctx => parameterTemplate(path(ctx))
+  return (input, executionContext) => parameterTemplate(path(input), executionContext)
 } // inputPathHandler
 
 module.exports = inputPathHandler

--- a/lib/state-machines/state-types/path-handlers/input-path-tokeniser.js
+++ b/lib/state-machines/state-types/path-handlers/input-path-tokeniser.js
@@ -3,6 +3,9 @@ const Tokenizr = require('tokenizr')
 const PARAMLIST = 'param-list'
 
 const lexer = new Tokenizr()
+lexer.rule(/^\$\$.*$/, (ctx, match) => {
+  ctx.accept('contextpath', match[0])
+})
 lexer.rule(/^\$.*$/, (ctx, match) => {
   ctx.accept('path', match[0])
 })
@@ -13,6 +16,9 @@ lexer.rule(/States.(\w+)\(/, (ctx, match) => {
 lexer.rule(/\)/, (ctx) => {
   ctx.accept('end-function', null)
   ctx.pop()
+})
+lexer.rule(PARAMLIST, /^\$\$.*$/, (ctx, match) => {
+  ctx.accept('contextpath', match[0])
 })
 lexer.rule(PARAMLIST, /\$[^, )]*/, (ctx, match) => {
   ctx.accept('path', match[0])

--- a/lib/state-machines/state-types/path-handlers/input-path-tokeniser.js
+++ b/lib/state-machines/state-types/path-handlers/input-path-tokeniser.js
@@ -3,8 +3,8 @@ const Tokenizr = require('tokenizr')
 const PARAMLIST = 'param-list'
 
 const lexer = new Tokenizr()
-lexer.rule(/^\$\$.*$/, (ctx, match) => {
-  ctx.accept('contextpath', match[0])
+lexer.rule(/^\$(\$.*$)/, (ctx, match) => {
+  ctx.accept('contextpath', match[1])
 })
 lexer.rule(/^\$.*$/, (ctx, match) => {
   ctx.accept('path', match[0])
@@ -17,8 +17,8 @@ lexer.rule(/\)/, (ctx) => {
   ctx.accept('end-function', null)
   ctx.pop()
 })
-lexer.rule(PARAMLIST, /^\$\$.*$/, (ctx, match) => {
-  ctx.accept('contextpath', match[0])
+lexer.rule(PARAMLIST, /^\$(\$.*$)/, (ctx, match) => {
+  ctx.accept('contextpath', match[1])
 })
 lexer.rule(PARAMLIST, /\$[^, )]*/, (ctx, match) => {
   ctx.accept('path', match[0])

--- a/lib/state-machines/state-types/path-handlers/input-path-tokeniser.js
+++ b/lib/state-machines/state-types/path-handlers/input-path-tokeniser.js
@@ -17,7 +17,7 @@ lexer.rule(/\)/, (ctx) => {
   ctx.accept('end-function', null)
   ctx.pop()
 })
-lexer.rule(PARAMLIST, /^\$(\$.*$)/, (ctx, match) => {
+lexer.rule(PARAMLIST, /\$(\$[^, )]*)/, (ctx, match) => {
   ctx.accept('contextpath', match[1])
 })
 lexer.rule(PARAMLIST, /\$[^, )]*/, (ctx, match) => {

--- a/lib/state-machines/state-types/path-handlers/payload-template-handler.js
+++ b/lib/state-machines/state-types/path-handlers/payload-template-handler.js
@@ -60,6 +60,7 @@ function makeDynamicHandler (params, references) {
 } // makeDynamicHandler
 
 const Evaluate = {
+  contextpath: evaluateContextObjectPath,
   path: evaluatePath,
   function: evaluateIntrinsic,
   string: token => token.value,
@@ -76,6 +77,10 @@ function evaluateExpression (expression, input) {
 function evaluateArgument (token, input) {
   return Evaluate[token.type](token, input)
 } // evaluateArgument
+
+function evaluateContextObjectPath ({ value }, input) {
+  return `context object ${value}`
+}
 
 function evaluatePath ({ value }, input) {
   return extractValue(_.cloneDeep(jp.query(input, value)))

--- a/lib/state-machines/state-types/path-handlers/payload-template-handler.js
+++ b/lib/state-machines/state-types/path-handlers/payload-template-handler.js
@@ -86,14 +86,14 @@ function evaluatePath ({ value }, input) {
   return extractValue(_.cloneDeep(jp.query(input, value)))
 } // evaluatePath
 
-function evaluateIntrinsic (func, input) {
+function evaluateIntrinsic (func, input, executionContext) {
   const fn = instrinsics[func.value]
   if (!fn) {
     ErrorStates.IntrinsicFailure.raise(`Unknown intrinsic States.${func.value}`)
   }
 
   try {
-    const values = func.parameters.map(token => evaluateArgument(token, input))
+    const values = func.parameters.map(token => evaluateArgument(token, input, executionContext))
 
     if (fn.validate) {
       fn.validate(func.parameters, values)

--- a/lib/state-machines/state-types/path-handlers/payload-template-handler.js
+++ b/lib/state-machines/state-types/path-handlers/payload-template-handler.js
@@ -48,10 +48,10 @@ function makeDynamicHandler (params, references) {
   const skeleton = skeletonizeParams(params, references)
   const replacers = makeReplacers(references)
 
-  return input => {
+  return (input, executionContext) => {
     const parameters = _.cloneDeep(skeleton)
     for (const [path, expr] of replacers) {
-      const extractedValue = evaluateExpression(expr, input)
+      const extractedValue = evaluateExpression(expr, input, executionContext)
 
       dottie.set(parameters, path, extractedValue)
     }
@@ -69,18 +69,18 @@ const Evaluate = {
   null: () => null
 } // Evaluate
 
-function evaluateExpression (expression, input) {
+function evaluateExpression (expression, input, executionContext) {
   const token = argTokeniser(expression)
-  return evaluateArgument(token, input)
+  return evaluateArgument(token, input, executionContext)
 } // evaluateExpression
 
-function evaluateArgument (token, input) {
-  return Evaluate[token.type](token, input)
+function evaluateArgument (token, input, executionContext) {
+  return Evaluate[token.type](token, input, executionContext)
 } // evaluateArgument
 
-function evaluateContextObjectPath ({ value }, input) {
-  return `context object ${value}`
-}
+function evaluateContextObjectPath (token, _, executionContext) {
+  return evaluatePath(token, executionContext)
+} // evaluateContextObjectPath
 
 function evaluatePath ({ value }, input) {
   return extractValue(_.cloneDeep(jp.query(input, value)))

--- a/test/context-object.js
+++ b/test/context-object.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+
+const chai = require('chai')
+const expect = chai.expect
+
+const contextObjectStateMachines = require('./fixtures/state-machines/context-object')
+
+const Statebox = require('./../lib')
+
+let statebox
+
+describe('Context Object', () => {
+  before('setup statebox', async () => {
+    statebox = new Statebox()
+    await statebox.ready
+    await statebox.createStateMachines(contextObjectStateMachines, {})
+  })
+
+  const today = new Date().toLocaleDateString('en-EN', { weekday: 'long' })
+
+  const contextObjectStates = {
+    NonExistantProperty: { oops: null },
+    DayOfWeek: { day: today },
+    FormattedDayOfWeek: { day: `The day is ${today}` }
+  }
+
+  for (const [name, result] of Object.entries(contextObjectStates)) {
+    test(name, result)
+  }
+})
+
+function test (statemachine, result) {
+  it(statemachine, async () => {
+    const executionDescription = await runStateMachine(statemachine)
+
+    expect(executionDescription.status).to.eql('SUCCEEDED')
+    expect(executionDescription.stateMachineName).to.eql(statemachine)
+    expect(executionDescription.currentResource).to.eql(undefined)
+    expect(executionDescription.ctx).to.eql(result)
+  }) // it ...
+}
+
+function runStateMachine (statemachine) {
+  return statebox.startExecution(
+    {}, // input
+    statemachine,
+    { sendResponse: 'COMPLETE' } // options
+  )
+}

--- a/test/context-object.js
+++ b/test/context-object.js
@@ -21,7 +21,7 @@ describe('Context Object', () => {
   const contextObjectStates = {
     NonExistantProperty: { oops: null },
     DayOfWeek: { day: today },
-    FormattedDayOfWeek: { day: `The day is ${today}` }
+    FormattedDayOfWeek: { day: `Today is ${today}` }
   }
 
   for (const [name, result] of Object.entries(contextObjectStates)) {

--- a/test/fixtures/state-machines/context-object/built-ins/day-of-week.json
+++ b/test/fixtures/state-machines/context-object/built-ins/day-of-week.json
@@ -1,0 +1,12 @@
+{
+  "StartAt": "First",
+  "States": {
+    "First": {
+      "Type": "Pass",
+      "Parameters": {
+        "day.$": "$$.DayOfWeek"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/fixtures/state-machines/context-object/built-ins/formatted-day-of-week.json
+++ b/test/fixtures/state-machines/context-object/built-ins/formatted-day-of-week.json
@@ -1,0 +1,12 @@
+{
+  "StartAt": "First",
+  "States": {
+    "First": {
+      "Type": "Pass",
+      "Parameters": {
+        "day.$": "States.Format('Today is {}', $$.DayOfWeek)"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/fixtures/state-machines/context-object/built-ins/non-existant.json
+++ b/test/fixtures/state-machines/context-object/built-ins/non-existant.json
@@ -1,0 +1,12 @@
+{
+  "StartAt": "First",
+  "States": {
+    "First": {
+      "Type": "Pass",
+      "Parameters": {
+        "oops.$": "$$.MissingProperty"
+      },
+      "End": true
+    }
+  }
+}

--- a/test/fixtures/state-machines/context-object/index.js
+++ b/test/fixtures/state-machines/context-object/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  NonExistantProperty: require('./built-ins/non-existant.json'),
+  DayOfWeek: require('./built-ins/day-of-week.json'),
+  FormattedDayOfWeek: require('./built-ins/formatted-day-of-week.json')
+}

--- a/test/pass-states.js
+++ b/test/pass-states.js
@@ -166,12 +166,12 @@ function test (label, statemachine, input, result) {
   }) // it ...
 }
 
-async function runStateMachine (statemachine, input) {
-  const executionDescription = await statebox.startExecution(
+function runStateMachine (statemachine, input) {
+  return statebox.startExecution(
     Object.assign({}, input),
     statemachine,
-    {} // options
+    {
+      sendResponse: 'COMPLETE'
+    } // options
   )
-
-  return statebox.waitUntilStoppedRunning(executionDescription.executionName)
 }


### PR DESCRIPTION
Implement the Context Object

The [specification](https://states-language.net/#context-object) talks about Context Object, but we already referred to the input as `ctx`, the context. Consequently, in our code I'm referring to the ExecutionContext rather than the Context Object. It's not the greatest name, but hopefully it's different enough from our existing names to be clear.

The change is relatively small - we simply use the ExecutionContext when we're evaluating a state's inputs. We don't need it anywhere else. There's a small change to the argument parser to accommodate the `$$.path` construction, and an extra evaluation function, but that's about it. 

The ExecutionContext object provides a number of read-only properties, some of which it derives from the state's execution description.
