### PR TITLE
Map & Parallel child branches need parents execution options passed down

### DIFF
--- a/lib/state-machines/state-types/Map.js
+++ b/lib/state-machines/state-types/Map.js
@@ -10,10 +10,10 @@ class Map extends ParentBaseState {
     // todo: MaxConcurrency
   }
 
-  buildBranchExecutions (input, parentExecutionName) {
+  buildBranchExecutions (input, parentExecutionName, executionOptions) {
     const branches = jp.value(input, this.itemsPath)
     return branches.map((item, index) =>
-      this.makeChildExecution(this.iterator, item, index, parentExecutionName)
+      this.makeChildExecution(this.iterator, item, index, parentExecutionName, executionOptions)
     )
   } // buildBranchExecutions
 } // class Map

--- a/lib/state-machines/state-types/Parallel.js
+++ b/lib/state-machines/state-types/Parallel.js
@@ -15,9 +15,9 @@ class Parallel extends ParentBaseState {
     this.debug()
   } // constructor
 
-  buildBranchExecutions (input, parentExecutionName) {
+  buildBranchExecutions (input, parentExecutionName, executionOptions) {
     return this.branches.map((stateMachineName, index) =>
-      this.makeChildExecution(stateMachineName, input, index, parentExecutionName)
+      this.makeChildExecution(stateMachineName, input, index, parentExecutionName, executionOptions)
     )
   } // buildBranchExecutions
 } // class Parallel

--- a/lib/state-machines/state-types/Parent-base-state.js
+++ b/lib/state-machines/state-types/Parent-base-state.js
@@ -13,7 +13,8 @@ class ParentBaseState extends BaseStateType {
     stateMachineName,
     input,
     index,
-    parentExecutionName
+    parentExecutionName,
+    executionOptions
   ) {
     const branchContext = cloneDeep(input)
 
@@ -21,6 +22,7 @@ class ParentBaseState extends BaseStateType {
       branchContext,
       stateMachineName,
       {
+        ...executionOptions,
         branchIndex: index,
         parentExecutionName,
         parentStateMachineName: this.stateMachineName,
@@ -35,7 +37,11 @@ class ParentBaseState extends BaseStateType {
     const parentExecutionName = executionDescription.executionName
     await this.dao.checkpoint(executionDescription)
 
-    const branchExecutions = this.buildBranchExecutions(input, parentExecutionName)
+    const branchExecutions = this.buildBranchExecutions(
+      input,
+      parentExecutionName,
+      executionDescription.executionOptions
+    )
 
     Promise
       .all(branchExecutions)

--- a/test/fixtures/state-machines/map-state/map.json
+++ b/test/fixtures/state-machines/map-state/map.json
@@ -8,8 +8,12 @@
       "ItemsPath": "$.shipped",
       "MaxConcurrency": 0,
       "Iterator": {
-        "StartAt": "Validate",
+        "StartAt": "Pass",
         "States": {
+          "Pass": {
+            "Type": "Pass",
+            "Next": "Validate"
+          },
           "Validate": {
             "Type": "Task",
             "Resource": "module:incrementQuantity",


### PR DESCRIPTION
Was called `runStateMachine` from a Map branch and it was failing in the RBAC because the userId wasn't being passed down to it. This small patch fixes that behaviour. 